### PR TITLE
calculated thumbrint is different from Java calculated thumbprint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ var crypto = require('crypto');
 
 module.exports.calculate = function (cert) {
 	var shasum = crypto.createHash('sha1');
-	var der = new Buffer(cert, 'base64')
+	var der = new Buffer(cert, 'base64');
 	shasum.update(der);
 	return shasum.digest('hex');
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ var crypto = require('crypto');
 
 module.exports.calculate = function (cert) {
 	var shasum = crypto.createHash('sha1');
-	var der = new Buffer(cert, 'base64').toString('binary')
+	var der = new Buffer(cert, 'base64')
 	shasum.update(der);
 	return shasum.digest('hex');
 }


### PR DESCRIPTION
Hello,
compared to the Java implementation, the binary string produces a different result. 
Using the **buffer directly** yields the same result as the Java (1.8) implementation.

Java Implementation Example:

```java
public String calculate(java.security.cert.X509Certificate cert)  throws CertificateEncodingException {
  MessageDigest md = MessageDigest.getInstance("SHA-1");
  byte[] der = cert.getEncoded();
  md.update(der);
  byte[] digest = md.digest();
  return DatatypeConverter.printHexBinary(digest).toLowerCase();
}
```

This Java Implementation returns the same thumbprint (fingerprint) hexstrings as the Java keytool when listing a keystore.

Best regards 
