### PR TITLE
Make compatible with Node 6

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@ var crypto = require('crypto');
 
 module.exports.calculate = function (cert) {
 	var shasum = crypto.createHash('sha1');
-	var der = new Buffer(cert, 'base64').toString('binary')
-	shasum.update(der);
+	shasum.update(new Buffer(cert, 'base64'));
 	return shasum.digest('hex');
 }


### PR DESCRIPTION
This change is needed because of the change in default encoding the in crypto module in Node 6: https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#crypto

Tested with Node 4:

```
> /tmp/fakepkg $ nvm use 4
Now using node v4.2.6 (npm v2.14.12)
/tmp/fakepkg $ node
> var thumbprint = require('thumbprint'); var fs = require('fs'); 
undefined
> thumbprint.calculate(fs.readFileSync('/tmp/cert.base64').toString())
'a937af980ae3f575b18378c4ba5a0256d6ee6982'
```

And Node 6:

```
/tmp/fakepkg $ nvm use 6
Now using node v6.11.3 (npm v3.10.10)
/tmp/fakepkg $ node
> var thumbprint = require('thumbprint'); var fs = require('fs');
undefined
> thumbprint.calculate(fs.readFileSync('/tmp/cert.base64').toString())
'a937af980ae3f575b18378c4ba5a0256d6ee6982'
```

Which are both the expected fingerprint according to `openssl`:

```
$ openssl x509 -in /tmp/cert.pem -fingerprint -noout
SHA1 Fingerprint=A9:37:AF:98:0A:E3:F5:75:B1:83:78:C4:BA:5A:02:56:D6:EE:69:82
```